### PR TITLE
libnftables-sys won't build on nftables-1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 readme = "README.md"
 
 [dependencies]
-json = "0.11"
+json = "0.12"
 
 [build-dependencies]
-bindgen = "0.37"
+bindgen = "0.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libnftables-sys"
 description = "FFI bindings for libnftables."
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Pierre Chifflier <chifflier@wzdftpd.net>"]
 license = "GPL-2.0"
 build = "build.rs"

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
+const DEFAULT_NFTABLES_INCLUDE_ARG: &str = "-I/usr/include/nftables";
+
 fn main() {
     if let Ok(dir) = env::var("NFTABLES_LIB_DIR") {
         println!("cargo:rustc-link-search=native={}", dir);
@@ -17,17 +19,19 @@ fn main() {
     let bindings = bindgen::Builder::default();
     let bindings = match env::var("NFTABLES_INCLUDE_DIR") {
         Ok(dir) => bindings.clang_arg(format!("-I{}", dir)),
-        _       => bindings
+        _       => bindings.clang_arg(DEFAULT_NFTABLES_INCLUDE_ARG)
     };
     let bindings = bindings
         // generate only nftables
-        .whitelist_function("nft_.*")
-        .whitelist_type("nft_.*")
+        .allowlist_function("nft_.*")
+        //.whitelist_type("nft_.*")
+        .allowlist_type("nft_.*")
+        .allowlist_var("NFT_CTX_.*")
         // do not bind functions using FILE
         .opaque_type("nft_ctx_set_output")
         .opaque_type("nft_ctx_set_error")
         // remove one extra type
-        .blacklist_type("__uint32_t")
+        .blocklist_type("__uint32_t")
         // simplify constants names
         .prepend_enum_name(false)
         // The input header we would like to generate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,74 +2,78 @@ extern crate json;
 
 mod bindings;
 
+use json::JsonValue;
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use json::JsonValue;
 
 pub use bindings::*;
 
 pub struct Nftables {
-    ctx: * mut nft_ctx,
+    ctx: *mut nft_ctx,
 }
 
-
 impl Nftables {
-    pub fn new() -> Nftables {
-        let ctx = unsafe{ nft_ctx_new(0) };
-        unsafe{ nft_ctx_output_set_echo(ctx, false) };
-        unsafe{ nft_ctx_buffer_output(ctx) };
-        unsafe{ nft_ctx_buffer_error(ctx) };
-        Nftables{
-            ctx
+    pub fn new() -> Self {
+        unsafe {
+            let ctx = nft_ctx_new(0);
+            nft_ctx_output_set_flags(ctx, NFT_CTX_DEFAULT);
+            nft_ctx_buffer_output(ctx);
+            nft_ctx_buffer_error(ctx);
+            Self { ctx }
         }
     }
 
-    pub fn run_cmd(&mut self, cmd: * const c_char) -> (i32,* const i8,* const i8) {
-        assert!(self.ctx != ::std::ptr::null_mut());
+    pub fn run_cmd(&mut self, cmd: *const c_char) -> (i32, *const i8, *const i8) {
+        assert!(!self.ctx.is_null());
 
-        let rc = unsafe{ nft_run_cmd_from_buffer(self.ctx, cmd) };
-        let output = unsafe{ nft_ctx_get_output_buffer(self.ctx) };
-        let error = unsafe{ nft_ctx_get_error_buffer(self.ctx) };
-
-        (rc,output,error)
+        unsafe {
+            (
+                nft_run_cmd_from_buffer(self.ctx, cmd),
+                nft_ctx_get_output_buffer(self.ctx),
+                nft_ctx_get_error_buffer(self.ctx),
+            )
+        }
     }
 
-    pub fn json_cmd(&mut self, cmd: * const c_char) -> (i32,JsonValue,* const i8) {
-        assert!(self.ctx != ::std::ptr::null_mut());
+    pub fn json_cmd(&mut self, cmd: *const c_char) -> (i32, JsonValue, *const i8) {
+        assert!(!self.ctx.is_null());
 
-        let old_json = unsafe{ nft_ctx_output_get_json(self.ctx) };
-        unsafe{ nft_ctx_output_set_json(self.ctx, true) };
-
-        let (rc,output,error) = self.run_cmd(cmd);
-
-        unsafe{ nft_ctx_output_set_json(self.ctx, old_json) };
-
-        if output == ::std::ptr::null() {
-            eprintln!("OUTPUT IS EMPTY");
-            return (rc,JsonValue::from(""),error);
-        }
-
-        let s = unsafe{ CStr::from_ptr(output) };
-        let output = match s.to_str() {
-            Ok(s) => JsonValue::from(s),
-            Err(e)=> panic!("Error converting output to UTF-8: {:?}", e),
+        let (rc, output, error) = unsafe {
+            let flags = nft_ctx_output_get_flags(self.ctx);
+            nft_ctx_output_set_flags(self.ctx, flags | NFT_CTX_OUTPUT_JSON);
+            let rc = nft_run_cmd_from_buffer(self.ctx, cmd);
+            let output = nft_ctx_get_output_buffer(self.ctx);
+            let error = nft_ctx_get_error_buffer(self.ctx);
+            nft_ctx_output_set_flags(self.ctx, flags);
+            (rc, output, error)
         };
 
-        (rc,output,error)
+        if output.is_null() {
+            eprintln!("OUTPUT IS EMPTY");
+            return (rc, JsonValue::from(""), error);
+        }
+
+        let s = unsafe { CStr::from_ptr(output) };
+        let output = match s.to_str() {
+            Ok(s) => JsonValue::from(s),
+            Err(e) => panic!("Error converting output to UTF-8: {:?}", e),
+        };
+
+        (rc, output, error)
     }
 
     pub fn set_debug(&mut self, flags: nft_debug_level) {
-        unsafe{ nft_ctx_output_set_debug(self.ctx, flags) };
+        unsafe { nft_ctx_output_set_debug(self.ctx, flags) };
     }
 
     pub fn get_debug(&self) -> nft_debug_level {
-        unsafe{ nft_ctx_output_get_debug(self.ctx) }
+        unsafe { nft_ctx_output_get_debug(self.ctx) }
     }
 }
 
 impl Drop for Nftables {
     fn drop(&mut self) {
-        unsafe{ nft_ctx_free(self.ctx) };
+        unsafe { nft_ctx_free(self.ctx) };
         self.ctx = ::std::ptr::null_mut();
     }
 }
@@ -85,14 +89,14 @@ mod tests {
 
     #[test]
     fn list_ruleset() {
-        assert_eq!(unsafe{ getuid() }, 0);
+        assert_eq!(unsafe { getuid() }, 0);
 
         let mut nft = Nftables::new();
 
         assert!(nft.ctx != ::std::ptr::null_mut());
 
         let cmd = CStr::from_bytes_with_nul(b"list ruleset\0").unwrap();
-        let (rc,output,error) = nft.run_cmd(cmd.as_ptr());
+        let (rc, output, error) = nft.run_cmd(cmd.as_ptr());
 
         assert_eq!(rc, 0);
         assert_ne!(output, ::std::ptr::null());


### PR DESCRIPTION
I was unable to build `libnftables-sys` 0.1.0 on my machine. I'm running FC35 and it includes version 1.0.0 of `libnftables`. This version of the library no longer includes the `nft_ctx_output_set_echo` function on which `libnftables-sys` relise and this is what leads to the build failure.

I tinkered a bit with `libnftables-sys` to obtain something that works (on my machine at least). Anyway, I thought I'd publish this here in case it proves useful to anyone else.