### PR TITLE
Add the repository link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Pierre Chifflier <chifflier@wzdftpd.net>"]
 license = "GPL-2.0"
 build = "build.rs"
 readme = "README.md"
+repository = "https://github.com/chifflier/libnftables-sys"
 
 [dependencies]
 json = "0.11"


### PR DESCRIPTION
It's not obvious where the code is from the crates page and thus not trivial to e.g. find the examples.